### PR TITLE
Hackathon feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**Important:** Read CONTRIBUTING.md before submitting feedback or contributing
-```
 
 
 
@@ -77,7 +75,7 @@ Table of Contents
    2.  Extended Error EDNS0 option format  . . . . . . . . . . . . .   4
    3.  Use of the Extended DNS Error option  . . . . . . . . . . . .   5
      3.1.  The R (Retry) flag  . . . . . . . . . . . . . . . . . . .   5
-     3.2.  The RESPONSE-CODE field . . . . . . . . . . . . . . . . .   5
+     3.2.  The RESPONSE-CODE field . . . . . . . . . . . . . . . . .   6
      3.3.  The INFO-CODE field . . . . . . . . . . . . . . . . . . .   6
      3.4.  The EXTRA-TEXT field  . . . . . . . . . . . . . . . . . .   6
    4.  Defined Extended DNS Errors . . . . . . . . . . . . . . . . .   6
@@ -86,28 +84,28 @@ Table of Contents
                DNSKEY Algorithm  . . . . . . . . . . . . . . . . . .   6
        4.1.2.  NOERROR Extended DNS Error Code 2 - Unsupported
                DS Algorithm  . . . . . . . . . . . . . . . . . . . .   6
-       4.1.3.  INFO-CODEs for use with RESPONSE-CODE: NOERROR(3) . .   6
-       4.1.4.  NOERROR Extended DNS Error Code 4 - Forged answer . .   7
-       4.1.5.  SERVFAIL Extended DNS Error Code 5 - DNSSEC
+     4.2.  INFO-CODEs for use with RESPONSE-CODE: NOERROR(3) . . . .   7
+       4.2.1.  NOERROR Extended DNS Error Code 3 - Stale Answer  . .   7
+       4.2.2.  NOERROR Extended DNS Error Code 4 - Forged Answer . .   7
+       4.2.3.  SERVFAIL Extended DNS Error Code 5 - DNSSEC
                Indeterminate . . . . . . . . . . . . . . . . . . . .   7
-     4.2.  INFO-CODEs for use with RESPONSE-CODE: SERVFAIL(2)  . . .   7
-       4.2.1.  SERVFAIL Extended DNS Error Code 1 - DNSSEC Bogus . .   7
-       4.2.2.  SERVFAIL Extended DNS Error Code 2 - Signature
+     4.3.  INFO-CODEs for use with RESPONSE-CODE: SERVFAIL(2)  . . .   7
+       4.3.1.  SERVFAIL Extended DNS Error Code 1 - DNSSEC Bogus . .   7
+       4.3.2.  SERVFAIL Extended DNS Error Code 2 - Signature
                Expired . . . . . . . . . . . . . . . . . . . . . . .   7
-       4.2.3.  SERVFAIL Extended DNS Error Code 3 - Signature Not
+       4.3.3.  SERVFAIL Extended DNS Error Code 3 - Signature Not
                Yet Valid . . . . . . . . . . . . . . . . . . . . . .   7
-       4.2.4.  SERVFAIL Extended DNS Error Code 4 - DNSKEY missing .   7
-       4.2.5.  SERVFAIL Extended DNS Error Code 5 - RRSIGs missing .   7
-       4.2.6.  SERVFAIL Extended DNS Error Code 6 - No Zone Key Bit
+       4.3.4.  SERVFAIL Extended DNS Error Code 4 - DNSKEY Missing .   7
+       4.3.5.  SERVFAIL Extended DNS Error Code 5 - RRSIGs Missing .   8
+       4.3.6.  SERVFAIL Extended DNS Error Code 6 - No Zone Key Bit
                Set . . . . . . . . . . . . . . . . . . . . . . . . .   8
-       4.2.7.  SERVFAIL Extended DNS Error Code 7 - No
+       4.3.7.  SERVFAIL Extended DNS Error Code 7 - No
                Reachable Authority . . . . . . . . . . . . . . . . .   8
-       4.2.8.  SERVFAIL Extended DNS Error Code 8 - NSEC Missing . .   8
-       4.2.9.  SERVFAIL Extended DNS Error Code 9 - Cached Error . .   8
-       4.2.10. SERVFAIL Extended DNS Error Code 10 - Not Ready . . .   8
-     4.3.  INFO-CODEs for use with RESPONSE-CODE: NOTIMP(4)  . . . .   8
-       4.3.1.  NOTIMP Extended DNS Error Code 1 - Deprecated . . . .   8
-     4.4.  INFO-CODEs for use with RESPONSE-CODE: REFUSED(5) . . . .   8
+       4.3.8.  SERVFAIL Extended DNS Error Code 8 - NSEC Missing . .   8
+       4.3.9.  SERVFAIL Extended DNS Error Code 9 - Cached Error . .   8
+       4.3.10. SERVFAIL Extended DNS Error Code 10 - Not Ready . . .   8
+       4.3.11. SERVFAIL Extended DNS Error Code 11 - Not Specified .   8
+     4.4.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)  . . .   8
 
 
 
@@ -116,24 +114,24 @@ Kumari, et al.         Expires September 12, 2019               [Page 2]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-       4.4.1.  REFUSED Extended DNS Error Code 1 - Lame  . . . . . .   8
-       4.4.2.  REFUSED Extended DNS Error Code 2 - Prohibited  . . .   9
-     4.5.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)  . . .   9
-       4.5.1.  NXDOMAIN Extended DNS Error Code 1 - Blocked  . . . .   9
-     4.6.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)  . . .   9
-       4.6.1.  NXDOMAIN Extended DNS Error Code 2 - Censored . . . .   9
-     4.7.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)  . . .   9
-       4.7.1.  NXDOMAIN Extended DNS Error Code 3 - Stale Answer . .   9
-   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
-     5.1.  A New Extended Error Code EDNS Option . . . . . . . . . .   9
+       4.4.1.  NXDOMAIN Extended DNS Error Code 1 - Blocked  . . . .   8
+       4.4.2.  NXDOMAIN Extended DNS Error Code 2 - Censored . . . .   9
+       4.4.3.  NXDOMAIN Extended DNS Error Code 3 - Stale Answer . .   9
+     4.5.  INFO-CODEs for use with RESPONSE-CODE: NOTIMP(4)  . . . .   9
+       4.5.1.  NOTIMP Extended DNS Error Code 1 - Deprecated . . . .   9
+     4.6.  INFO-CODEs for use with RESPONSE-CODE: REFUSED(5) . . . .   9
+       4.6.1.  REFUSED Extended DNS Error Code 1 - Lame  . . . . . .   9
+       4.6.2.  REFUSED Extended DNS Error Code 2 - Prohibited  . . .   9
+   5.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+     5.1.  A New Extended Error Code EDNS Option . . . . . . . . . .  10
      5.2.  New Double-Index Registry Table for Extended Error Codes   10
-   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   6.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
    7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .  13
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  14
    Appendix A.  Changes / Author Notes.  . . . . . . . . . . . . . .  14
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  14
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  15
 
 1.  Introduction and background
 
@@ -228,8 +226,11 @@ Kumari, et al.         Expires September 12, 2019               [Page 4]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-   o  RESPONSE-CODE, 4 bits.
-   o  INFO-CODE, 12-bits.
+   o  RESPONSE-CODE, 4 bits.  (Note: RESPONSE-CODE and INFO-CODE
+      together comprise a 2-octet field in network byte order, of which
+      RESPONSE-CODE is the most significant 4 bits.)
+   o  INFO-CODE, 12 bits.  (The least significant 12 bits of the
+      combined 2-octet field described above.)
    o  EXTRA-TEXT, a variable length, UTF-8 encoded, text field that may
       hold additional textual information.
 
@@ -237,10 +238,15 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
    The Extended DNS Error (EDE) is an EDNS option.  It can be included
    in any response (SERVFAIL, NXDOMAIN, REFUSED, etc) to a query that
-   includes OPT Pseudo-RR [RFC6891].  This document includes a set of
-   initial codepoints (and requests to the IANA to add them to the
-   registry), but is extensible via the IANA registry to allow
-   additional error and information codes to be defined in the future.
+   includes OPT Pseudo-RR [RFC6891].  A sender MUST NOT include more
+   than one Extended DNS Error option per message; additional Extended
+   DNS Error options after the first one MUST be ignored by the
+   receiver.
+
+   This document includes a set of initial codepoints (and requests to
+   the IANA to add them to the registry), but is extensible via the IANA
+   registry to allow additional error and information codes to be
+   defined in the future.
 
    The fields of the Extended DNS Error option are defined further in
    the following sub-sections.
@@ -266,14 +272,6 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    ignore this hint.  See the security considerations for additional
    considerations.
 
-3.2.  The RESPONSE-CODE field
-
-   This 4-bit value SHOULD be a copy of the RCODE from the primary DNS
-   packet.  RESPONSE-CODEs MAY use a different RCODE to provide
-   additional or better information.  For example, multiple EDNS0/EDE
-   records may be included in the response and the supplemental EDNS0/
-   EDE records may wish to include other RESPONSE-CODE values based on
-   communication results with other DNS servers.
 
 
 
@@ -283,6 +281,12 @@ Kumari, et al.         Expires September 12, 2019               [Page 5]
 
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
+
+3.2.  The RESPONSE-CODE field
+
+   This 4-bit value SHOULD be a copy of the RCODE from the primary DNS
+   packet.  RESPONSE-CODEs MAY use a different RCODE to provide
+   additional or better information.
 
 3.3.  The INFO-CODE field
 
@@ -326,12 +330,6 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    The resolver attempted to perform DNSSEC validation, but a DS RRSET
    contained only unknown algorithms.  The R flag should be set.
 
-4.1.3.  INFO-CODEs for use with RESPONSE-CODE: NOERROR(3)
-
-
-
-
-
 
 
 
@@ -340,7 +338,9 @@ Kumari, et al.         Expires September 12, 2019               [Page 6]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-4.1.3.1.  NOERROR Extended DNS Error Code 3 - Stale Answer
+4.2.  INFO-CODEs for use with RESPONSE-CODE: NOERROR(3)
+
+4.2.1.  NOERROR Extended DNS Error Code 3 - Stale Answer
 
    The resolver was unable to resolve answer within its time limits and
    decided to answer with a previously cached data instead of answering
@@ -349,43 +349,41 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    set, since retrying is likely to create additional load without
    yielding a more fresh answer.
 
-4.1.4.  NOERROR Extended DNS Error Code 4 - Forged answer
+4.2.2.  NOERROR Extended DNS Error Code 4 - Forged Answer
 
    For policy reasons (legal obligation, or malware filtering, for
    instance), an answer was forged.  The R flag should not be set.
 
-4.1.5.  SERVFAIL Extended DNS Error Code 5 - DNSSEC Indeterminate
+4.2.3.  SERVFAIL Extended DNS Error Code 5 - DNSSEC Indeterminate
 
    The resolver attempted to perform DNSSEC validation, but validation
    ended in the Indeterminate state.  The R flag should not be set.
 
-4.2.  INFO-CODEs for use with RESPONSE-CODE: SERVFAIL(2)
+4.3.  INFO-CODEs for use with RESPONSE-CODE: SERVFAIL(2)
 
-4.2.1.  SERVFAIL Extended DNS Error Code 1 - DNSSEC Bogus
+4.3.1.  SERVFAIL Extended DNS Error Code 1 - DNSSEC Bogus
 
    The resolver attempted to perform DNSSEC validation, but validation
    ended in the Bogus state.  The R flag should not be set.
 
-4.2.2.  SERVFAIL Extended DNS Error Code 2 - Signature Expired
+4.3.2.  SERVFAIL Extended DNS Error Code 2 - Signature Expired
 
    The resolver attempted to perform DNSSEC validation, a signature in
    the validation chain was expired.  The R flag should not be set.
 
-4.2.3.  SERVFAIL Extended DNS Error Code 3 - Signature Not Yet Valid
+4.3.3.  SERVFAIL Extended DNS Error Code 3 - Signature Not Yet Valid
 
    The resolver attempted to perform DNSSEC validation, but the
    signatures received were not yet valid.  The R flag should not be
    set.
 
-4.2.4.  SERVFAIL Extended DNS Error Code 4 - DNSKEY missing
+4.3.4.  SERVFAIL Extended DNS Error Code 4 - DNSKEY Missing
 
    A DS record existed at a parent, but no supported matching DNSKEY
    record could be found for the child.  The R flag should not be set.
 
-4.2.5.  SERVFAIL Extended DNS Error Code 5 - RRSIGs missing
 
-   The resolver attempted to perform DNSSEC validation, but no RRSIGs
-   could be found for at least one RRset where RRSIGs were expected.
+
 
 
 
@@ -396,50 +394,50 @@ Kumari, et al.         Expires September 12, 2019               [Page 7]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-4.2.6.  SERVFAIL Extended DNS Error Code 6 - No Zone Key Bit Set
+4.3.5.  SERVFAIL Extended DNS Error Code 5 - RRSIGs Missing
+
+   The resolver attempted to perform DNSSEC validation, but no RRSIGs
+   could be found for at least one RRset where RRSIGs were expected.
+
+4.3.6.  SERVFAIL Extended DNS Error Code 6 - No Zone Key Bit Set
 
    The resolver attempted to perform DNSSEC validation, but no Zone Key
    Bit was set in a DNSKEY.
 
-4.2.7.  SERVFAIL Extended DNS Error Code 7 - No Reachable Authority
+4.3.7.  SERVFAIL Extended DNS Error Code 7 - No Reachable Authority
 
    The resolver could not reach any of the authoritative name servers
    (or they refused to reply).  The R flag should be set.
 
-4.2.8.  SERVFAIL Extended DNS Error Code 8 - NSEC Missing
+4.3.8.  SERVFAIL Extended DNS Error Code 8 - NSEC Missing
 
    The resolver attempted to perform DNSSEC validation, but the
    requested data was missing and a covering NSEC or NSEC3 was not
    provided.  The R flag should be set.
 
-4.2.9.  SERVFAIL Extended DNS Error Code 9 - Cached Error
+4.3.9.  SERVFAIL Extended DNS Error Code 9 - Cached Error
 
    The resolver has cached SERVFAIL for this query without additional
    information.  Th R flag should be set.
 
-4.2.10.  SERVFAIL Extended DNS Error Code 10 - Not Ready
+4.3.10.  SERVFAIL Extended DNS Error Code 10 - Not Ready
 
    The server is unable to answer the query as it is not fully up and
    functional yet.
 
-4.3.  INFO-CODEs for use with RESPONSE-CODE: NOTIMP(4)
+4.3.11.  SERVFAIL Extended DNS Error Code 11 - Not Specified
 
-4.3.1.  NOTIMP Extended DNS Error Code 1 - Deprecated
+   A generic code which may be used when a SERVFAIL response does not
+   fall into any of the other categories.  The R flag should not be set.
 
-   The requested operation or query is not supported as its use has been
-   deprecated.  Implementations should not set the R flag.  (Retrying
-   request elsewhere is unlikely to yield any other results.)
+4.4.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)
 
-4.4.  INFO-CODEs for use with RESPONSE-CODE: REFUSED(5)
+4.4.1.  NXDOMAIN Extended DNS Error Code 1 - Blocked
 
-4.4.1.  REFUSED Extended DNS Error Code 1 - Lame
+   The resolver attempted to perfom a DNS query but the domain is
+   blacklisted due to a security policy implemented on the server being
+   directly talked to.  The R flag should be set.
 
-   An authoritative server that receives a query (with the RD bit clear)
-   for a domain for which it is not authoritative SHOULD include this
-   EDE code in the SERVFAIL response.  A resolver that receives a query
-   (with the RD bit clear) SHOULD include this EDE code in the REFUSED
-   response.  Implementations should set the R flag in this case
-   (another nameserver or resolver might not be lame).
 
 
 
@@ -452,7 +450,42 @@ Kumari, et al.         Expires September 12, 2019               [Page 8]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-4.4.2.  REFUSED Extended DNS Error Code 2 - Prohibited
+4.4.2.  NXDOMAIN Extended DNS Error Code 2 - Censored
+
+   The resolver attempted to perfom a DNS query but the domain was
+   blacklisted by a security policy imposed upon the server being talked
+   to.  Note that how the imposed policy is applied is irrelevant (in-
+   band DNS somehow, court order, etc).  The R flag should be set.
+
+4.4.3.  NXDOMAIN Extended DNS Error Code 3 - Stale Answer
+
+   The resolver was unable to resolve answer within its time limits and
+   decided to answer with a previously cached NXDOMAIN answer instead of
+   answering with an error.  This is typically caused by problems on
+   authoritative side, possibly as result of a DoS attack.  The R flag
+   should not be set, since retrying is likely to create additional load
+   without yielding a more fresh answer.
+
+4.5.  INFO-CODEs for use with RESPONSE-CODE: NOTIMP(4)
+
+4.5.1.  NOTIMP Extended DNS Error Code 1 - Deprecated
+
+   The requested operation or query is not supported as its use has been
+   deprecated.  Implementations should not set the R flag.  (Retrying
+   request elsewhere is unlikely to yield any other results.)
+
+4.6.  INFO-CODEs for use with RESPONSE-CODE: REFUSED(5)
+
+4.6.1.  REFUSED Extended DNS Error Code 1 - Lame
+
+   An authoritative server that receives a query (with the RD bit clear)
+   for a domain for which it is not authoritative SHOULD include this
+   EDE code in the SERVFAIL response.  A resolver that receives a query
+   (with the RD bit clear) SHOULD include this EDE code in the REFUSED
+   response.  Implementations should set the R flag in this case
+   (another nameserver or resolver might not be lame).
+
+4.6.2.  REFUSED Extended DNS Error Code 2 - Prohibited
 
    An authoritative or recursive resolver that receives a query from an
    "unauthorized" client can annotate its REFUSED message with this
@@ -463,33 +496,15 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    Implementations SHOULD allow operators to define what to set the R
    flag to in this case.
 
-4.5.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)
 
-4.5.1.  NXDOMAIN Extended DNS Error Code 1 - Blocked
 
-   The resolver attempted to perfom a DNS query but the domain is
-   blacklisted due to a security policy implemented on the server being
-   directly talked to.  The R flag should be set.
 
-4.6.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)
 
-4.6.1.  NXDOMAIN Extended DNS Error Code 2 - Censored
 
-   The resolver attempted to perfom a DNS query but the domain was
-   blacklisted by a security policy imposed upon the server being talked
-   to.  Note that how the imposed policy is applied is irrelevant (in-
-   band DNS somehow, court order, etc).  The R flag should be set.
+Kumari, et al.         Expires September 12, 2019               [Page 9]
+
+Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
-4.7.  INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)
-
-4.7.1.  NXDOMAIN Extended DNS Error Code 3 - Stale Answer
-
-   The resolver was unable to resolve answer within its time limits and
-   decided to answer with a previously cached NXDOMAIN answer instead of
-   answering with an error.  This is typically caused by problems on
-   authoritative side, possibly as result of a DoS attack.  The R flag
-   should not be set, since retrying is likely to create additional load
-   without yielding a more fresh answer.
 
 5.  IANA Considerations
 
@@ -500,13 +515,6 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    (OPT)" registry [to be removed upon publication:
    [http://www.iana.org/assignments/dns-parameters/dns-
    parameters.xhtml#dns-parameters-11]
-
-
-
-Kumari, et al.         Expires September 12, 2019               [Page 9]
-
-Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
-
 
    Value  Name                 Status    Reference
    -----  ----------------     ------    ------------------
@@ -538,24 +546,14 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    Purpose:  Unsupported DS Algorithm
    Reference:  Section 4.1.2
 
-   RESPONSE-CODE:  3 (NOERROR)
+   RESPONSE-CODE:  0 (NOERROR)
    INFO-CODE:  3
    Purpose:  Answering with stale/cached data
-   Reference:  Section 4.1.3.1
+   Reference:  Section 4.2.1
 
    RESPONSE-CODE:  0 (NOERROR)
    INFO-CODE:  4
-   Purpose:  Forged answer
-   Reference:  Section 4.1.4
-
-   RESPONSE-CODE:  0 (NOERROR)
-   INFO-CODE:  5
-   Purpose:  DNSSEC Indeterminate
-   Reference:  Section 4.1.5
-
-   RESPONSE-CODE:  2 (SERVFAIL)
-   INFO-CODE:  1
-   Purpose:  DNSSEC Bogus
+   Purpose:  Forged Answer
 
 
 
@@ -564,54 +562,54 @@ Kumari, et al.         Expires September 12, 2019              [Page 10]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
-   Reference:  Section 4.2.1
+   Reference:  Section 4.2.2
+
+   RESPONSE-CODE:  0 (NOERROR)
+   INFO-CODE:  5
+   Purpose:  DNSSEC Indeterminate
+   Reference:  Section 4.2.3
+
+   RESPONSE-CODE:  2 (SERVFAIL)
+   INFO-CODE:  1
+   Purpose:  DNSSEC Bogus
+   Reference:  Section 4.3.1
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  2
    Purpose:  Signature Expired
-   Reference:  Section 4.2.2
+   Reference:  Section 4.3.2
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  3
    Purpose:  Signature Not Yet Valid
-   Reference:  Section 4.2.3
+   Reference:  Section 4.3.3
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  4
-   Purpose:  DNSKEY missing
-   Reference:  Section 4.2.4
+   Purpose:  DNSKEY Missing
+   Reference:  Section 4.3.4
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  5
-   Purpose:  RRSIGs missing
-   Reference:  Section 4.2.5
+   Purpose:  RRSIGs Missing
+   Reference:  Section 4.3.5
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  6
    Purpose:  No Zone Key Bit Set
-   Reference:  Section 4.2.6
+   Reference:  Section 4.3.6
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  7
-   Purpose:  No NSEC records could be obtained
-   Reference:  Section 4.2.8
+   Purpose:  No Reachable Authority
+   Reference:  Section 4.3.7
 
    RESPONSE-CODE:  2 (SERVFAIL)
    INFO-CODE:  9
-   Purpose:  The SERVFAIL error comes from the cache
-   Reference:  Section 4.2.9
+   Purpose:  NSEC Missing
+   Reference:  Section 4.3.8
 
    RESPONSE-CODE:  2 (SERVFAIL)
-   INFO-CODE:  10
-   Purpose:  Not Ready.
-   Reference:  Section 4.2.10
-
-   RESPONSE-CODE:  3 (NXDOMAIN)
-   INFO-CODE:  1
-   Purpose:  Blocked
-   Reference:  Section 4.5.1
-
-   RESPONSE-CODE:  3 (NXDOMAIN)
 
 
 
@@ -620,29 +618,61 @@ Kumari, et al.         Expires September 12, 2019              [Page 11]
 Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
+   INFO-CODE:  9
+   Purpose:  The SERVFAIL error comes from the cache
+   Reference:  Section 4.3.9
+
+   RESPONSE-CODE:  2 (SERVFAIL)
+   INFO-CODE:  10
+   Purpose:  Not Ready.
+   Reference:  Section 4.3.10
+
+   RESPONSE-CODE:  2 (SERVFAIL)
+   INFO-CODE:  11
+   Purpose:  Not Specified.
+   Reference:  Section 4.3.11
+
+   RESPONSE-CODE:  3 (NXDOMAIN)
+   INFO-CODE:  1
+   Purpose:  Blocked
+   Reference:  Section 4.4.1
+
+   RESPONSE-CODE:  3 (NXDOMAIN)
    INFO-CODE:  2
    Purpose:  Censored
-   Reference:  Section 4.6.1
+   Reference:  Section 4.4.2
 
    RESPONSE-CODE:  3 (NXDOMAIN)
    INFO-CODE:  3
    Purpose:  Answering with stale/cached NXDOMAIN data
-   Reference:  Section 4.7.1
+   Reference:  Section 4.4.3
 
    RESPONSE-CODE:  4 (NOTIMP)
    INFO-CODE:  1
-   Purpose:
-   Reference:  Section 4.4.2
+   Purpose:  Deprecated
+   Reference:  Section 4.6.2
 
    RESPONSE-CODE:  5 (REFUSED)
    INFO-CODE:  1
    Purpose:  Lame
-   Reference:  Section 4.4.1
+   Reference:  Section 4.6.1
 
    RESPONSE-CODE:  5 (REFUSED)
    INFO-CODE:  2
    Purpose:  Prohibited
-   Reference:  Section 4.4.2
+   Reference:  Section 4.6.2
+
+
+
+
+
+
+
+
+Kumari, et al.         Expires September 12, 2019              [Page 12]
+
+Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
+
 
 6.  Security Considerations
 
@@ -669,24 +699,16 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
    validating resolvers / stubs may choose to put a different weight on
    it.
 
-
-
-Kumari, et al.         Expires September 12, 2019              [Page 12]
-
-Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
-
-
 7.  Acknowledgements
 
    The authors wish to thank Joe Abley, Mark Andrews, Stephane
    Bortzmeyer, Vladimir Cunat, Peter DeVries, Peter van Dijk, Donald
-   Eastlake, Bob Harold, Evan Hunt, Geoff Huston, Shane Kerr, Edward
-   Lewis, Carlos M.  Martinez, George Michelson, Michael Sheldon, Petr
-   Spacek, Ondrej Sury, Loganaden Velvindron, and Paul Vixie.  They also
-   vaguely remember discussing this with a number of people over the
-   years, but have forgotten who all they were -- if you were one of
-   them, and are not listed, please let us know and we'll acknowledge
-   you.
+   Eastlake, Bob Harold, Geoff Huston, Shane Kerr, Edward Lewis, Carlos
+   M.  Martinez, George Michelson, Michael Sheldon, Petr Spacek, Ondrej
+   Sury, Loganaden Velvindron, and Paul Vixie.  They also vaguely
+   remember discussing this with a number of people over the years, but
+   have forgotten who all they were -- if you were one of them, and are
+   not listed, please let us know and we'll acknowledge you.
 
    I also want to thank the band "Infected Mushroom" for providing a
    good background soundtrack (and to see if I can get away with this!)
@@ -696,6 +718,17 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 8.  References
 
 8.1.  Normative References
+
+
+
+
+
+
+
+Kumari, et al.         Expires September 12, 2019              [Page 13]
+
+Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
+
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -724,14 +757,6 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
               DOI 10.17487/RFC8094, February 2017, <https://www.rfc-
               editor.org/info/rfc8094>.
 
-
-
-
-Kumari, et al.         Expires September 12, 2019              [Page 13]
-
-Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
-
-
 Appendix A.  Changes / Author Notes.
 
    [RFC Editor: Please remove this section before publication ]
@@ -753,6 +778,13 @@ Appendix A.  Changes / Author Notes.
    o  Added David Lawrence -- I somehow missed that in last version.
 
    From -00 to -01;
+
+
+
+Kumari, et al.         Expires September 12, 2019              [Page 14]
+
+Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
+
 
    o  Fixed up some of the text, minor clarifications.
 
@@ -782,12 +814,6 @@ Authors' Addresses
    Email: roy.arends@icann.org
 
 
-
-Kumari, et al.         Expires September 12, 2019              [Page 14]
-
-Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
-
-
    Wes Hardaker
    USC/ISI
    P.O. Box 382
@@ -811,33 +837,4 @@ Internet-Draft       draft-ietf-dnsop-extended-error          March 2019
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 Kumari, et al.         Expires September 12, 2019              [Page 15]
-```

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -700,7 +700,7 @@
     <section title="Acknowledgements">
       <t>The authors wish to thank Joe Abley, Mark Andrews, Stephane
       Bortzmeyer, Vladimir Cunat, Peter DeVries, Peter van Dijk,
-      Donald Eastlake, Bob Harold, Evan Hunt, Geoff Huston, Shane
+      Donald Eastlake, Bob Harold, Geoff Huston, Shane
       Kerr, Edward Lewis, Carlos M.  Martinez, George Michelson,
       Michael Sheldon, Petr Spacek, Ondrej Sury, Loganaden Velvindron,
       and Paul Vixie.  They also vaguely remember discussing this with

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -212,9 +212,12 @@
           bits MUST be set to 0 by the sender and MUST be ignored by
           the receiver.</t>
 
-          <t>RESPONSE-CODE, 4 bits.</t>
+	  <t>RESPONSE-CODE, 4 bits. (Note: RESPONSE-CODE and INFO-CODE
+	  together comprise a 2-octet field in network byte order, of which
+	  RESPONSE-CODE is the most significant 4 bits.)</t>
 
-          <t>INFO-CODE, 12-bits.</t>
+	  <t>INFO-CODE, 12 bits. (The least significant 12 bits of the
+	  combined 2-octet field described above.)</t>
 
           <t>EXTRA-TEXT, a variable length, UTF-8 encoded, text field
           that may hold additional textual information.</t>
@@ -224,11 +227,16 @@
 
     <section title="Use of the Extended DNS Error option">
       <t>The Extended DNS Error (EDE) is an EDNS option. It can be included
-        in any response (SERVFAIL, NXDOMAIN, REFUSED, etc) to a query that
-        includes OPT Pseudo-RR <xref target="RFC6891" />. This document includes a set of initial
-      codepoints (and requests to the IANA to add them to the registry), but
-      is extensible via the IANA registry to allow additional error and
-      information codes to be defined in the future.</t>
+      in any response (SERVFAIL, NXDOMAIN, REFUSED, etc) to a query that
+      includes OPT Pseudo-RR <xref target="RFC6891" />. A sender MUST NOT
+      include more than one Extended DNS Error option per message;
+      additional Extended DNS Error options after the first one MUST be
+      ignored by the receiver.</t>
+
+      <t>This document includes a set of initial codepoints (and requests
+      to the IANA to add them to the registry), but is extensible via the
+      IANA registry to allow additional error and information codes to be
+      defined in the future.</t>
 
       <t>The fields of the Extended DNS Error option are defined
       further in the following sub-sections.</t>
@@ -260,11 +268,7 @@
       <section title="The RESPONSE-CODE field">
 	  <t>This 4-bit value SHOULD be a copy of the RCODE from the
 	  primary DNS packet. RESPONSE-CODEs MAY use a different RCODE
-	  to provide additional or better information.  For example,
-	  multiple EDNS0/EDE records may be included in the response
-	  and the supplemental EDNS0/EDE records may wish to include
-	  other RESPONSE-CODE values based on communication results with
-	  other DNS servers.</t>
+	  to provide additional or better information.</t>
       </section>
 
       <section title="The INFO-CODE field">

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -334,7 +334,7 @@
       </section>
 
         <section anchor="forgedanswer"
-                 title="NOERROR Extended DNS Error Code 4 - Forged answer">
+                 title="NOERROR Extended DNS Error Code 4 - Forged Answer">
           <t>For policy reasons (legal obligation, or malware
           filtering, for instance), an answer was forged.  The R flag
           should not be set.</t>
@@ -374,14 +374,14 @@
         </section>
 
         <section anchor="errnodnskey"
-                 title="SERVFAIL Extended DNS Error Code 4 - DNSKEY missing">
+                 title="SERVFAIL Extended DNS Error Code 4 - DNSKEY Missing">
           <t>A DS record existed at a parent, but no supported
           matching DNSKEY record could be found for the child. The R
           flag should not be set.</t>
         </section>
 
         <section anchor="errnorrsig"
-                 title="SERVFAIL Extended DNS Error Code 5 - RRSIGs missing">
+                 title="SERVFAIL Extended DNS Error Code 5 - RRSIGs Missing">
           <t>The resolver attempted to perform DNSSEC validation, but no
           RRSIGs could be found for at least one RRset where RRSIGs were
           expected.</t>
@@ -558,7 +558,7 @@
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 0 (NOERROR)</t>
     <t hangText="INFO-CODE:">4</t>
-    <t hangText="Purpose:">Forged answer</t>
+    <t hangText="Purpose:">Forged Answer</t>
     <t hangText="Reference:"><xref target="forgedanswer" /></t>
     </list></t>
 
@@ -593,14 +593,14 @@
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 2 (SERVFAIL)</t>
     <t hangText="INFO-CODE:">4</t>
-    <t hangText="Purpose:">DNSKEY missing</t>
+    <t hangText="Purpose:">DNSKEY Missing</t>
     <t hangText="Reference:"> <xref target="errnodnskey" /></t>
     </list></t>
 
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 2 (SERVFAIL)</t>
     <t hangText="INFO-CODE:">5</t>
-    <t hangText="Purpose:">RRSIGs missing</t>
+    <t hangText="Purpose:">RRSIGs Missing</t>
     <t hangText="Reference:"><xref target="errnorrsig" /></t>
     </list></t>
 

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -403,8 +403,8 @@
         <section anchor="nonsec"
                  title="SERVFAIL Extended DNS Error Code 8 - NSEC Missing">
           <t>The resolver attempted to perform DNSSEC validation, but the
-          requested data was missing and a covering NSEC or NSEC3 was not provided.
-          The R flag should be set.</t>
+          requested data was missing and a covering NSEC or NSEC3 was not
+          provided. The R flag should be set.</t>
         </section>
 
         <section anchor="cachederror"
@@ -417,6 +417,13 @@
                  title="SERVFAIL Extended DNS Error Code 10 - Not Ready">
           <t>The server is unable to answer the query as it is not
           fully up and functional yet.</t>
+        </section>
+
+        <section anchor="notspecified"
+                 title="SERVFAIL Extended DNS Error Code 11 - Not Specified">
+	  <t>A generic code which may be used when a SERVFAIL response does
+	  not fall into any of the other categories. The R flag should not be
+	  set.</t>
         </section>
       </section>
 

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -541,7 +541,7 @@
     </list></t>
 
     <t><list style="hanging" hangIndent="10">
-    <t hangText="RESPONSE-CODE:"> 3 (NOERROR)</t>
+    <t hangText="RESPONSE-CODE:"> 0 (NOERROR)</t>
     <t hangText="INFO-CODE:">3</t>
     <t hangText="Purpose:">Answering with stale/cached data</t>
     <t hangText="Reference:"><xref target="stalenoerror" /></t>
@@ -606,7 +606,14 @@
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 2 (SERVFAIL)</t>
     <t hangText="INFO-CODE:">7</t>
-    <t hangText="Purpose:">No NSEC records could be obtained</t>
+    <t hangText="Purpose:">No Reachable Authority</t>
+    <t hangText="Reference:"><xref target="noauth" /></t>
+    </list></t>
+
+    <t><list style="hanging" hangIndent="10">
+    <t hangText="RESPONSE-CODE:"> 2 (SERVFAIL)</t>
+    <t hangText="INFO-CODE:">9</t>
+    <t hangText="Purpose:">NSEC Missing</t>
     <t hangText="Reference:"><xref target="nonsec" /></t>
     </list></t>
 
@@ -623,7 +630,14 @@
     <t hangText="Purpose:">Not Ready.</t>
     <t hangText="Reference:"><xref target="notready" /></t>
     </list></t>
-    
+
+    <t><list style="hanging" hangIndent="10">
+    <t hangText="RESPONSE-CODE:"> 2 (SERVFAIL)</t>
+    <t hangText="INFO-CODE:">11</t>
+    <t hangText="Purpose:">Not Specified.</t>
+    <t hangText="Reference:"><xref target="notspecified" /></t>
+    </list></t>
+
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 3 (NXDOMAIN)</t>
     <t hangText="INFO-CODE:">1</t>
@@ -648,10 +662,10 @@
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 4 (NOTIMP)</t>
     <t hangText="INFO-CODE:">1</t>
-    <t hangText="Purpose:"></t>
+    <t hangText="Purpose:">Deprecated</t>
     <t hangText="Reference:"><xref target="errprohibted" /></t>
     </list></t>
-    
+
     <t><list style="hanging" hangIndent="10">
     <t hangText="RESPONSE-CODE:"> 5 (REFUSED)</t>
     <t hangText="INFO-CODE:">1</t>

--- a/draft-ietf-dnsop-extended-error.xml
+++ b/draft-ietf-dnsop-extended-error.xml
@@ -319,6 +319,7 @@
           RRSET contained only unknown algorithms. The R flag should be
           set.</t>
         </section>
+      </section>
 
       <section title="INFO-CODEs for use with RESPONSE-CODE: NOERROR(3)">
         <section anchor="stalenoerror"
@@ -331,7 +332,6 @@
           retrying is likely to create additional load without
           yielding a more fresh answer.</t>
         </section>
-      </section>
 
         <section anchor="forgedanswer"
                  title="NOERROR Extended DNS Error Code 4 - Forged Answer">
@@ -346,10 +346,7 @@
           validation ended in the Indeterminate state. The R flag should not
           be set.</t>
         </section>
-
       </section>
-
-
 
       <section title="INFO-CODEs for use with RESPONSE-CODE: SERVFAIL(2)">
         <section anchor="errbogus"
@@ -427,6 +424,36 @@
         </section>
       </section>
 
+      <section title="INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)">
+        <section anchor="errblocked"
+	         title="NXDOMAIN Extended DNS Error Code 1 - Blocked">
+          <t>The resolver attempted to perfom a DNS query but the
+          domain is blacklisted due to a security policy implemented
+          on the server being directly talked to. The R flag should be
+          set.</t>
+        </section>
+
+        <section anchor="errcensored"
+	         title="NXDOMAIN Extended DNS Error Code 2 - Censored">
+          <t>The resolver attempted to perfom a DNS query but the
+          domain was blacklisted by a security policy imposed upon the
+          server being talked to. Note that how the imposed policy is
+          applied is irrelevant (in-band DNS somehow, court order,
+          etc). The R flag should be set.</t>
+        </section>
+
+        <section anchor="stalenx"
+	         title="NXDOMAIN Extended DNS Error Code 3 - Stale Answer">
+          <t>The resolver was unable to resolve answer within its time
+          limits and decided to answer with a previously cached
+          NXDOMAIN answer instead of answering with an error.  This is
+          typically caused by problems on authoritative side, possibly
+          as result of a DoS attack. The R flag should not be set,
+          since retrying is likely to create additional load without
+          yielding a more fresh answer.</t>
+        </section>
+      </section>
+
       <section title="INFO-CODEs for use with RESPONSE-CODE: NOTIMP(4)">
 	<section anchor="deprecated"
 	         title="NOTIMP Extended DNS Error Code 1 - Deprecated">
@@ -435,7 +462,6 @@
           R flag. (Retrying request elsewhere is unlikely to yield any
           other results.)</t>
         </section>
-
       </section>
 
       <section title="INFO-CODEs for use with RESPONSE-CODE: REFUSED(5)">
@@ -460,40 +486,6 @@
 
           <t>Implementations SHOULD allow operators to define what to set the
           R flag to in this case.</t>
-        </section>
-      </section>
-
-      <section title="INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)">
-        <section anchor="errblocked"
-	         title="NXDOMAIN Extended DNS Error Code 1 - Blocked">
-          <t>The resolver attempted to perfom a DNS query but the
-          domain is blacklisted due to a security policy implemented
-          on the server being directly talked to. The R flag should be
-          set.</t>
-        </section>
-      </section>
-
-      <section title="INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)">
-        <section anchor="errcensored"
-	         title="NXDOMAIN Extended DNS Error Code 2 - Censored">
-          <t>The resolver attempted to perfom a DNS query but the
-          domain was blacklisted by a security policy imposed upon the
-          server being talked to. Note that how the imposed policy is
-          applied is irrelevant (in-band DNS somehow, court order,
-          etc). The R flag should be set.</t>
-        </section>
-      </section>
-
-      <section title="INFO-CODEs for use with RESPONSE-CODE: NXDOMAIN(3)">
-        <section anchor="stalenx"
-	         title="NXDOMAIN Extended DNS Error Code 3 - Stale Answer">
-          <t>The resolver was unable to resolve answer within its time
-          limits and decided to answer with a previously cached
-          NXDOMAIN answer instead of answering with an error.  This is
-          typically caused by problems on authoritative side, possibly
-          as result of a DoS attack. The R flag should not be set,
-          since retrying is likely to create additional load without
-          yielding a more fresh answer.</t>
         </section>
       </section>
     </section>


### PR DESCRIPTION
Stephane Bortzmeyer worked on implementing EDE in Knot the hackathon in Prague, and mentioned a few issues that came up:

1. INFO-CODE bit layout was a bit ambiguous as it's a 12-bit field and "byte order" isn't meaningful. The packet layout diagram helps, but we could help by specifing in the text that the combined response and info fields are two octets in network byte order, and RESPONSE-CODE is the most significant four bits and INFO-CODE is the least significant 12.

2. He requested the addition of a generic error code for SERVFAIL responses that don't fall into any defined category. For example, it's possible to configure Knot to send SERVFAIL as a result of a policy decision, which doesn't fall into any of the existing buckets, and it would seem silly to add a specific bucket for that.

3. Finally, he recommended removal of the suggestion in section 3.2 that multiple EDE records could be included with a response, and instead forbid it. It makes parsing harder, and it's unclear what to do if different codes contradict one another.

4. Incidental point that I noticed while checking the existing text: "The authors wish to thank...Evan
Hunt" looks weird if I'm one of authors...